### PR TITLE
🧼  Fixed the null/indefined query params

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,10 @@
     "indent": ["error", 2, { "SwitchCase": 1 }],
     "linebreak-style": ["error", "unix"],
     "quotes": ["error", "single", { "avoidEscape": true }],
-    "semi": ["error", "never"]
+    "semi": ["error", "never"],
+    "no-unused-vars": ["error", {
+        "argsIgnorePattern": "^_|[Ii]gnore$",
+        "varsIgnorePattern": "^_|[Ii]gnore$"
+    }]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "creditsafe-node-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Node.js Client for Creditsafe Connect API",
   "keywords": [
     "creditsafe.com",

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,8 +80,11 @@ export class Creditsafe {
     // build up the complete url from the provided 'uri' and the 'host'
     let url = new URL(PROTOCOL+'://'+path.join(this.host, uri))
     if (query) {
-      Object.keys(query).forEach(k =>
-        url.searchParams.append(k, query[k].toString()))
+      Object.keys(query).forEach(k => {
+        if (something(query[k])) {
+          url.searchParams.append(k, query[k].toString())
+        }
+      })
     }
     const isForm = isFormData(body)
     // make the appropriate headers
@@ -127,6 +130,14 @@ export class Creditsafe {
     // this will mean we retried, and still failed
     return { response }
   }
+}
+
+/*
+ * Simple function used to weed out undefined and null query params before
+ * trying to place them on the call.
+ */
+function something(arg: any) {
+  return arg || arg === false || arg === 0 || arg === ''
 }
 
 /*

--- a/tests/people.ts
+++ b/tests/people.ts
@@ -15,7 +15,7 @@ import { Creditsafe } from '../src/index'
     peopleId: 'US-S340823369',
   })
   if (one.success) {
-    console.log(`Success! We found the director Donna Richards`)
+    console.log('Success! We found the director Donna Richards')
   } else {
     console.log('Error! I was not able to find Donna Richards, and I should.')
     console.log(one)


### PR DESCRIPTION
When we passed in the argument to the search, or really, *any* of the
calls, we didn't filter out the null/undefined ones, so that when we
went to add them as query params to the call, the toString() would blow
up if they were null/undefined. This fix takes care of that so we don't
have to worry about it in the calling.